### PR TITLE
Change dark guide colors to base01

### DIFF
--- a/styles/syntax-variables-dark.less
+++ b/styles/syntax-variables-dark.less
@@ -5,9 +5,9 @@
 @syntax-background-color: @base16-color-base00;
 
 // Guide colors
-@syntax-wrap-guide-color: @base16-color-base03;
-@syntax-indent-guide-color: @base16-color-base03;
-@syntax-invisible-character-color: @base16-color-base03;
+@syntax-wrap-guide-color: @base16-color-base01;
+@syntax-indent-guide-color: @base16-color-base01;
+@syntax-invisible-character-color: @base16-color-base01;
 
 // For find and replace markers
 @syntax-result-marker-color: @base16-color-base03;


### PR DESCRIPTION
This makes them more mellow against the base00 background and symmetric to light theme setup: light themes are [background-guides-text] 07-06-02, so dark counterparts should be 00-01-05, not 00-03-05

![2015-07-25-173326_291x207_scrot](https://cloud.githubusercontent.com/assets/1104527/8889259/6163a198-32ec-11e5-9eb8-e31ee4cbaa97.png)  => ![2015-07-25-173426_296x209_scrot](https://cloud.githubusercontent.com/assets/1104527/8889260/688fd4f0-32ec-11e5-83ce-6648460cfb2f.png)