### PR TITLE
Use theme colours for VCS status.

### DIFF
--- a/styles/syntax-variables-dark.less
+++ b/styles/syntax-variables-dark.less
@@ -20,7 +20,7 @@
 @syntax-gutter-background-color-selected: fade(@base16-color-base03, 33%);
 
 // For git diff info. i.e. in the gutter
-@syntax-color-added: green;
-@syntax-color-modified: orange;
-@syntax-color-removed: red;
-@syntax-color-renamed: blue;
+@syntax-color-added: @base16-color-base0B;
+@syntax-color-modified: @base16-color-base09;
+@syntax-color-removed: @base16-color-base08;
+@syntax-color-renamed: @base16-color-base0D;

--- a/styles/syntax-variables-light.less
+++ b/styles/syntax-variables-light.less
@@ -20,7 +20,7 @@
 @syntax-gutter-background-color-selected: fade(@base16-color-base04, 33%);
 
 // For git diff info. i.e. in the gutter
-@syntax-color-added: green;
-@syntax-color-modified: orange;
-@syntax-color-removed: red;
-@syntax-color-renamed: blue;
+@syntax-color-added: @base16-color-base0B;
+@syntax-color-modified: @base16-color-base09;
+@syntax-color-removed: @base16-color-base08;
+@syntax-color-renamed: @base16-color-base0D;


### PR DESCRIPTION
Default theming for VCS status colors can be really ugly, especially in the tree view when the UI theme doesn't have good defaults of its own. This gives a good red/orange-yellow/green scheme that matches the syntax theme.