### PR TITLE
Properly highlight stdint types

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -229,6 +229,10 @@
     .if (@base16-style, 'dark', color, @base16-color-base0A);
     .if (@base16-style, 'light', color, @base16-color-base09);
   }
+  
+  &.syntax--type {
+    color: @base16-color-base0C;
+  }
 
   &.syntax--function {
     color: @base16-color-base0C;


### PR DESCRIPTION
Similar/identical to what [atom/one-light-syntax](https://github.com/atom/one-light-syntax) does. Allows stdint types (int8_t, uint32_t, etc) to stand out.